### PR TITLE
refactor: split models into separate modules

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+__pycache__/
+*.pyc
+.pytest_cache/

--- a/app/database.py
+++ b/app/database.py
@@ -1,0 +1,3 @@
+from sqlalchemy.orm import declarative_base
+
+Base = declarative_base()

--- a/app/models/__init__.py
+++ b/app/models/__init__.py
@@ -1,0 +1,49 @@
+from .base import (
+    Base,
+    TimestampMixin,
+    SoftDeleteMixin,
+    ContactMixin,
+    HospitalType,
+    AccreditationStatus,
+    PaymentStatus,
+    TaskPriority,
+    LeadStatus,
+    UserRole,
+)
+from .user import User
+from .client import Client, ContactPerson
+from .service import Service
+from .lead import Lead
+from .project import Project, Quote, Agreement, Milestone
+from .payment import Payment
+from .document import Document
+from .task import Task
+from .note import Note
+from .notification import Notification
+
+__all__ = [
+    "Base",
+    "TimestampMixin",
+    "SoftDeleteMixin",
+    "ContactMixin",
+    "HospitalType",
+    "AccreditationStatus",
+    "PaymentStatus",
+    "TaskPriority",
+    "LeadStatus",
+    "UserRole",
+    "User",
+    "Client",
+    "ContactPerson",
+    "Service",
+    "Lead",
+    "Project",
+    "Quote",
+    "Agreement",
+    "Milestone",
+    "Payment",
+    "Document",
+    "Task",
+    "Note",
+    "Notification",
+]

--- a/app/models/base.py
+++ b/app/models/base.py
@@ -1,0 +1,72 @@
+from sqlalchemy import Column, Date, DateTime, Enum, Float, Integer, String, Text, Boolean, ForeignKey, UniqueConstraint, func
+from sqlalchemy.orm import relationship, validates
+from app.database import Base
+import enum
+import re
+
+# Enums
+class HospitalType(str, enum.Enum):
+    SINGLE_SPECIALTY = "Single Specialty"
+    MULTI_SPECIALTY = "Multi Specialty"
+    CLINIC = "Clinic"
+    DIAGNOSTIC_CENTER = "Diagnostic Center"
+    HOSPITAL_CHAIN = "Hospital Chain"
+
+class AccreditationStatus(str, enum.Enum):
+    DRAFT = "Draft"
+    IN_PROGRESS = "In Progress"
+    ACCREDITED = "Accredited"
+    REJECTED = "Rejected"
+    RENEWAL_PENDING = "Renewal Pending"
+
+class PaymentStatus(str, enum.Enum):
+    PENDING = "Pending"
+    PARTIAL = "Partial"
+    PAID = "Paid"
+    OVERDUE = "Overdue"
+    REFUNDED = "Refunded"
+
+class TaskPriority(str, enum.Enum):
+    LOW = "Low"
+    MEDIUM = "Medium"
+    HIGH = "High"
+    CRITICAL = "Critical"
+
+class LeadStatus(str, enum.Enum):
+    NEW = "New"
+    CONTACTED = "Contacted"
+    QUALIFIED = "Qualified"
+    PROPOSAL_SENT = "Proposal Sent"
+    NEGOTIATION = "Negotiation"
+    CONVERTED = "Converted"
+    CLOSED_LOST = "Closed Lost"
+    ON_HOLD = "On Hold"
+
+class UserRole(str, enum.Enum):
+    ADMIN = "admin"
+    MANAGER = "manager"
+    USER = "user"
+
+# Mixins
+class TimestampMixin:
+    created_at = Column(DateTime, server_default=func.now())
+    updated_at = Column(DateTime, onupdate=func.now())
+
+class SoftDeleteMixin:
+    is_deleted = Column(Boolean, default=False)
+
+class ContactMixin:
+    email = Column(String(120), index=True)
+    phone = Column(String(20))
+    whatsapp = Column(String(20))
+    address = Column(Text)
+    city = Column(String(50))
+    state = Column(String(50))
+    country = Column(String(50), default="India")
+    postal_code = Column(String(15))
+
+    @validates("phone", "whatsapp")
+    def validate_phone(self, key, value):
+        if value and not value.startswith("+"):
+            raise ValueError("Phone number must start with '+'")
+        return value

--- a/app/models/client.py
+++ b/app/models/client.py
@@ -1,0 +1,32 @@
+from sqlalchemy import Boolean, Column, ForeignKey, Integer, String, Enum
+from sqlalchemy.orm import relationship
+from .base import Base, ContactMixin, TimestampMixin, SoftDeleteMixin, HospitalType
+
+class Client(Base, ContactMixin, TimestampMixin, SoftDeleteMixin):
+    __tablename__ = "clients"
+    id = Column(Integer, primary_key=True)
+    name = Column(String(100))
+    hospital_name = Column(String(200))
+    beds = Column(Integer)
+    hospital_type = Column(Enum(HospitalType))
+    director_name = Column(String(100))
+    website = Column(String(200))
+    is_active = Column(Boolean, default=True)
+
+    projects = relationship("Project", back_populates="client", cascade="all, delete-orphan")
+    leads = relationship("Lead", back_populates="client", cascade="all, delete-orphan")
+    payments = relationship("Payment", back_populates="client", cascade="all, delete-orphan")
+    contacts = relationship("ContactPerson", back_populates="client", cascade="all, delete-orphan")
+    documents = relationship("Document", back_populates="client")
+
+class ContactPerson(Base, TimestampMixin):
+    __tablename__ = "contact_persons"
+    id = Column(Integer, primary_key=True)
+    client_id = Column(Integer, ForeignKey("clients.id"))
+    name = Column(String(100))
+    designation = Column(String(100))
+    email = Column(String(120))
+    phone = Column(String(20))
+    is_primary = Column(Boolean, default=False)
+
+    client = relationship("Client", back_populates="contacts")

--- a/app/models/document.py
+++ b/app/models/document.py
@@ -1,0 +1,18 @@
+from sqlalchemy import Column, ForeignKey, Integer, String
+from sqlalchemy.orm import relationship
+from .base import Base, TimestampMixin
+
+class Document(Base, TimestampMixin):
+    __tablename__ = "documents"
+    id = Column(Integer, primary_key=True)
+    client_id = Column(Integer, ForeignKey("clients.id"))
+    lead_id = Column(Integer, ForeignKey("leads.id"))
+    project_id = Column(Integer, ForeignKey("projects.id"))
+    name = Column(String(200))
+    document_type = Column(String(50))
+    file_url = Column(String(400))
+    uploaded_by_id = Column(Integer, ForeignKey("users.id"))
+
+    client = relationship("Client", back_populates="documents")
+    lead = relationship("Lead", back_populates="documents")
+    uploaded_by = relationship("User")

--- a/app/models/lead.py
+++ b/app/models/lead.py
@@ -1,0 +1,27 @@
+from sqlalchemy import Column, DateTime, Enum, Float, ForeignKey, Integer, String, UniqueConstraint
+from sqlalchemy.orm import relationship
+from .base import Base, TimestampMixin, SoftDeleteMixin, LeadStatus, TaskPriority
+
+class Lead(Base, TimestampMixin, SoftDeleteMixin):
+    __tablename__ = "leads"
+    id = Column(Integer, primary_key=True)
+    client_id = Column(Integer, ForeignKey("clients.id"))
+    service_id = Column(Integer, ForeignKey("services.id"))
+    source = Column(String(100))
+    status = Column(Enum(LeadStatus), default=LeadStatus.NEW, index=True)
+    probability = Column(Integer, default=30)
+    priority = Column(Enum(TaskPriority), default=TaskPriority.MEDIUM)
+    assigned_to_id = Column(Integer, ForeignKey("users.id"))
+    next_follow_up = Column(DateTime, index=True)
+    estimated_value = Column(Float)
+
+    __table_args__ = (
+        UniqueConstraint("client_id", "service_id", name="uq_lead_per_service_per_client"),
+    )
+
+    client = relationship("Client", back_populates="leads")
+    service = relationship("Service", back_populates="leads")
+    assigned_to = relationship("User", back_populates="assigned_leads")
+    notes = relationship("Note", back_populates="lead")
+    tasks = relationship("Task", back_populates="lead")
+    documents = relationship("Document", back_populates="lead")

--- a/app/models/note.py
+++ b/app/models/note.py
@@ -1,0 +1,15 @@
+from sqlalchemy import Column, ForeignKey, Integer, Text
+from sqlalchemy.orm import relationship
+from .base import Base, TimestampMixin
+
+class Note(Base, TimestampMixin):
+    __tablename__ = "notes"
+    id = Column(Integer, primary_key=True)
+    content = Column(Text)
+    author_id = Column(Integer, ForeignKey("users.id"))
+    lead_id = Column(Integer, ForeignKey("leads.id"))
+    project_id = Column(Integer, ForeignKey("projects.id"))
+
+    author = relationship("User", back_populates="notes")
+    lead = relationship("Lead", back_populates="notes")
+    project = relationship("Project")

--- a/app/models/notification.py
+++ b/app/models/notification.py
@@ -1,0 +1,14 @@
+from sqlalchemy import Boolean, Column, ForeignKey, Integer, String, Text
+from sqlalchemy.orm import relationship
+from .base import Base, TimestampMixin
+
+class Notification(Base, TimestampMixin):
+    __tablename__ = "notifications"
+    id = Column(Integer, primary_key=True)
+    user_id = Column(Integer, ForeignKey("users.id"))
+    message = Column(Text)
+    is_read = Column(Boolean, default=False)
+    link_to = Column(String(200))
+    notification_type = Column(String(50))
+
+    user = relationship("User", back_populates="notifications")

--- a/app/models/payment.py
+++ b/app/models/payment.py
@@ -1,0 +1,19 @@
+from sqlalchemy import Column, Date, Enum, Float, ForeignKey, Integer, String, Text
+from sqlalchemy.orm import relationship
+from .base import Base, TimestampMixin, PaymentStatus
+
+class Payment(Base, TimestampMixin):
+    __tablename__ = "payments"
+    id = Column(Integer, primary_key=True)
+    client_id = Column(Integer, ForeignKey("clients.id"), index=True)
+    project_id = Column(Integer, ForeignKey("projects.id"), index=True)
+    amount = Column(Float)
+    due_date = Column(Date)
+    paid_date = Column(Date)
+    reference_no = Column(String(100))
+    status = Column(Enum(PaymentStatus), default=PaymentStatus.PENDING)
+    payment_method = Column(String(50))
+    notes = Column(Text)
+
+    client = relationship("Client", back_populates="payments")
+    project = relationship("Project", back_populates="payments")

--- a/app/models/project.py
+++ b/app/models/project.py
@@ -1,0 +1,63 @@
+from sqlalchemy import Column, Date, Enum, Float, ForeignKey, Integer, String, Text, Boolean
+from sqlalchemy.orm import relationship
+from .base import Base, TimestampMixin, SoftDeleteMixin, AccreditationStatus
+
+class Project(Base, TimestampMixin, SoftDeleteMixin):
+    __tablename__ = "projects"
+    id = Column(Integer, primary_key=True)
+    client_id = Column(Integer, ForeignKey("clients.id"))
+    service_id = Column(Integer, ForeignKey("services.id"))
+    title = Column(String(200))
+    status = Column(Enum(AccreditationStatus), default=AccreditationStatus.DRAFT)
+    start_date = Column(Date)
+    target_date = Column(Date)
+    completed_date = Column(Date)
+    expected_fee = Column(Float)
+    actual_fee = Column(Float)
+
+    client = relationship("Client", back_populates="projects")
+    service = relationship("Service", back_populates="projects")
+    quotes = relationship("Quote", back_populates="project", cascade="all, delete-orphan")
+    agreements = relationship("Agreement", back_populates="project", cascade="all, delete-orphan")
+    tasks = relationship("Task", back_populates="project")
+    milestones = relationship("Milestone", back_populates="project")
+    payments = relationship("Payment", back_populates="project", lazy="selectin")
+
+class Quote(Base, TimestampMixin):
+    __tablename__ = "quotes"
+    id = Column(Integer, primary_key=True)
+    project_id = Column(Integer, ForeignKey("projects.id"))
+    version = Column(Integer, default=1)
+    quote_no = Column(String(50), unique=True)
+    amount = Column(Float)
+    discount_pct = Column(Float)
+    valid_until = Column(Date)
+    terms = Column(Text)
+    is_accepted = Column(Boolean, default=False)
+
+    project = relationship("Project", back_populates="quotes")
+
+class Agreement(Base, TimestampMixin):
+    __tablename__ = "agreements"
+    id = Column(Integer, primary_key=True)
+    project_id = Column(Integer, ForeignKey("projects.id"))
+    agreement_no = Column(String(50), unique=True)
+    start_date = Column(Date)
+    end_date = Column(Date)
+    signed_date = Column(Date)
+    file_url = Column(String(400))
+    termination_clause = Column(Text)
+    is_active = Column(Boolean, default=True)
+
+    project = relationship("Project", back_populates="agreements")
+
+class Milestone(Base, TimestampMixin):
+    __tablename__ = "milestones"
+    id = Column(Integer, primary_key=True)
+    project_id = Column(Integer, ForeignKey("projects.id"))
+    name = Column(String(150))
+    target_date = Column(Date)
+    completed_date = Column(Date)
+    status = Column(String(30), default="Pending")
+
+    project = relationship("Project", back_populates="milestones")

--- a/app/models/service.py
+++ b/app/models/service.py
@@ -1,0 +1,15 @@
+from sqlalchemy import Boolean, Column, Float, Integer, String, Text
+from sqlalchemy.orm import relationship
+from .base import Base, TimestampMixin
+
+class Service(Base, TimestampMixin):
+    __tablename__ = "services"
+    id = Column(Integer, primary_key=True)
+    name = Column(String(100), unique=True)
+    description = Column(Text)
+    standard_fee = Column(Float)
+    duration_days = Column(Integer)
+    is_active = Column(Boolean, default=True)
+
+    leads = relationship("Lead", back_populates="service")
+    projects = relationship("Project", back_populates="service")

--- a/app/models/task.py
+++ b/app/models/task.py
@@ -1,0 +1,19 @@
+from sqlalchemy import Column, DateTime, Enum, ForeignKey, Integer, String, Text
+from sqlalchemy.orm import relationship
+from .base import Base, TimestampMixin, TaskPriority
+
+class Task(Base, TimestampMixin):
+    __tablename__ = "tasks"
+    id = Column(Integer, primary_key=True)
+    title = Column(String(200))
+    description = Column(Text)
+    due_date = Column(DateTime)
+    priority = Column(Enum(TaskPriority), default=TaskPriority.MEDIUM)
+    status = Column(String(20), default="Pending")
+    assigned_to_id = Column(Integer, ForeignKey("users.id"))
+    lead_id = Column(Integer, ForeignKey("leads.id"))
+    project_id = Column(Integer, ForeignKey("projects.id"))
+
+    assigned_to = relationship("User", back_populates="tasks")
+    lead = relationship("Lead", back_populates="tasks")
+    project = relationship("Project", back_populates="tasks")

--- a/app/models/user.py
+++ b/app/models/user.py
@@ -1,0 +1,27 @@
+from sqlalchemy import Boolean, Column, DateTime, Integer, String, Enum
+from sqlalchemy.orm import relationship, validates
+from .base import Base, TimestampMixin, SoftDeleteMixin, UserRole
+import re
+
+class User(Base, TimestampMixin, SoftDeleteMixin):
+    __tablename__ = "users"
+    id = Column(Integer, primary_key=True)
+    username = Column(String(50), unique=True)
+    email = Column(String(120), unique=True)
+    password_hash = Column(String(128))
+    full_name = Column(String(100))
+    role = Column(Enum(UserRole), default=UserRole.USER)
+    token_version = Column(Integer, default=0)
+    is_active = Column(Boolean, default=True)
+    last_login = Column(DateTime)
+
+    assigned_leads = relationship("Lead", back_populates="assigned_to")
+    tasks = relationship("Task", back_populates="assigned_to")
+    notes = relationship("Note", back_populates="author")
+    notifications = relationship("Notification", back_populates="user")
+
+    @validates("email")
+    def validate_email(self, key, email):
+        if email and not re.match(r"[^@]+@[^@]+\.[^@]+", email):
+            raise ValueError("Invalid email address")
+        return email


### PR DESCRIPTION
## Summary
- factor models into dedicated modules for each domain
- centralize enums and mixins in a shared base module and expose them via models package
- refine models with role enum, token version, phone validation, and performance indexes

## Testing
- `python -m py_compile $(find app -name '*.py')`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68958cd100b08329ad08e3232ad76b77