### PR TITLE
refactor: split models into separate modules

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+__pycache__/
+*.pyc
+.pytest_cache/

--- a/app/api/__init__.py
+++ b/app/api/__init__.py
@@ -1,0 +1,46 @@
+from __future__ import annotations
+
+from fastapi import APIRouter
+
+from app import schemas
+from app.crud import get_crud
+from app.models import (
+    Client,
+    Document,
+    Lead,
+    Note,
+    Notification,
+    Payment,
+    Project,
+    Service,
+    Task,
+    User,
+)
+
+from .factory import generate_router
+
+MODELS = [
+    User,
+    Client,
+    Lead,
+    Project,
+    Payment,
+    Service,
+    Document,
+    Task,
+    Note,
+    Notification,
+]
+
+api_router = APIRouter()
+
+for m in MODELS:
+    crud = get_crud(m)
+    schema_read = getattr(schemas, f"{m.__name__}Read")
+    schema_create = getattr(schemas, f"{m.__name__}Create")
+    schema_update = getattr(schemas, f"{m.__name__}Update")
+    api_router.include_router(
+        generate_router(m.__name__, crud, schema_read, schema_create, schema_update)
+    )
+
+__all__ = ["api_router"]

--- a/app/api/__init__.py
+++ b/app/api/__init__.py
@@ -18,6 +18,7 @@ from app.models import (
 )
 
 from .factory import generate_router
+from .auth import router as auth_router
 
 MODELS = [
     User,
@@ -33,6 +34,9 @@ MODELS = [
 ]
 
 api_router = APIRouter()
+
+# authentication routes
+api_router.include_router(auth_router)
 
 for m in MODELS:
     crud = get_crud(m)

--- a/app/api/auth.py
+++ b/app/api/auth.py
@@ -1,0 +1,57 @@
+from datetime import timedelta
+
+from fastapi import APIRouter, Depends, HTTPException, status
+from fastapi.security import OAuth2PasswordBearer, OAuth2PasswordRequestForm
+from jose import JWTError, jwt
+from sqlalchemy.orm import Session
+
+from app import schemas
+from app.database import get_db
+from app.models import User
+from app.security import (
+    ALGORITHM,
+    SECRET_KEY,
+    create_access_token,
+    verify_password,
+)
+
+oauth2_scheme = OAuth2PasswordBearer(tokenUrl="/auth/token")
+
+router = APIRouter(prefix="/auth", tags=["auth"])
+
+
+@router.post("/token", response_model=schemas.Token)
+def login_for_access_token(
+    form_data: OAuth2PasswordRequestForm = Depends(),
+    db: Session = Depends(get_db),
+):
+    user = db.query(User).filter(User.username == form_data.username).first()
+    if not user or not verify_password(form_data.password, user.password_hash):
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="Incorrect username or password",
+            headers={"WWW-Authenticate": "Bearer"},
+        )
+    access_token = create_access_token(str(user.id))
+    return {"access_token": access_token, "token_type": "bearer"}
+
+
+def get_current_user(
+    db: Session = Depends(get_db), token: str = Depends(oauth2_scheme)
+) -> User:
+    try:
+        payload = jwt.decode(token, SECRET_KEY, algorithms=[ALGORITHM])
+        user_id: str | None = payload.get("sub")
+        if user_id is None:
+            raise HTTPException(status_code=401, detail="Invalid token")
+    except JWTError:
+        raise HTTPException(status_code=401, detail="Invalid token")
+    user = db.get(User, int(user_id))
+    if user is None:
+        raise HTTPException(status_code=404, detail="User not found")
+    return user
+
+
+@router.get("/me", response_model=schemas.UserRead)
+def read_current_user(current_user: User = Depends(get_current_user)):
+    return current_user

--- a/app/api/factory.py
+++ b/app/api/factory.py
@@ -7,6 +7,7 @@ from sqlalchemy.orm import Session
 
 from app.crud.base import CRUDBase
 from app.database import get_db
+from .auth import get_current_user
 
 
 def generate_router(
@@ -18,7 +19,11 @@ def generate_router(
 ) -> APIRouter:
     """Create an APIRouter with standard CRUD endpoints for a model."""
 
-    router = APIRouter(prefix=f"/{model_name.lower()}", tags=[model_name])
+    router = APIRouter(
+        prefix=f"/{model_name.lower()}",
+        tags=[model_name],
+        dependencies=[Depends(get_current_user)],
+    )
 
     @router.get("/", response_model=list[schema_read])
     def read_items(db: Session = Depends(get_db)):

--- a/app/api/factory.py
+++ b/app/api/factory.py
@@ -1,0 +1,54 @@
+from __future__ import annotations
+
+from typing import Type
+
+from fastapi import APIRouter, Depends, HTTPException
+from sqlalchemy.orm import Session
+
+from app.crud.base import CRUDBase
+from app.database import get_db
+
+
+def generate_router(
+    model_name: str,
+    crud: CRUDBase,
+    schema_read: Type,
+    schema_create: Type,
+    schema_update: Type,
+) -> APIRouter:
+    """Create an APIRouter with standard CRUD endpoints for a model."""
+
+    router = APIRouter(prefix=f"/{model_name.lower()}", tags=[model_name])
+
+    @router.get("/", response_model=list[schema_read])
+    def read_items(db: Session = Depends(get_db)):
+        return crud.get_multi(db)
+
+    @router.post("/", response_model=schema_read)
+    def create_item(item: schema_create, db: Session = Depends(get_db)):
+        return crud.create(db, item)
+
+    @router.get("/{item_id}", response_model=schema_read)
+    def read_item(item_id: int, db: Session = Depends(get_db)):
+        obj = crud.get(db, item_id)
+        if obj is None:
+            raise HTTPException(status_code=404, detail="Item not found")
+        return obj
+
+    @router.put("/{item_id}", response_model=schema_read)
+    def update_item(
+        item_id: int, item: schema_update, db: Session = Depends(get_db)
+    ):
+        db_obj = crud.get(db, item_id)
+        if db_obj is None:
+            raise HTTPException(status_code=404, detail="Item not found")
+        return crud.update(db, db_obj, item)
+
+    @router.delete("/{item_id}", response_model=schema_read)
+    def delete_item(item_id: int, db: Session = Depends(get_db)):
+        obj = crud.remove(db, item_id)
+        if obj is None:
+            raise HTTPException(status_code=404, detail="Item not found")
+        return obj
+
+    return router

--- a/app/crud/__init__.py
+++ b/app/crud/__init__.py
@@ -1,0 +1,45 @@
+from __future__ import annotations
+
+from typing import Dict, Type
+
+from app.models import (
+    Client,
+    Document,
+    Lead,
+    Note,
+    Notification,
+    Payment,
+    Project,
+    Service,
+    Task,
+    User,
+)
+
+from .base import CRUDBase
+
+MODELS = [
+    User,
+    Client,
+    Lead,
+    Project,
+    Payment,
+    Service,
+    Document,
+    Task,
+    Note,
+    Notification,
+]
+
+crud_map: Dict[str, CRUDBase] = {m.__name__: CRUDBase(m) for m in MODELS}
+
+
+def get_crud(model: Type) -> CRUDBase:
+    """Return CRUD instance for a given model class."""
+    return crud_map[model.__name__]
+
+
+# Expose CRUD instances as module-level variables for convenience
+for _model in MODELS:
+    globals()[_model.__name__.lower()] = crud_map[_model.__name__]
+
+__all__ = [m.__name__.lower() for m in MODELS] + ["get_crud"]

--- a/app/crud/base.py
+++ b/app/crud/base.py
@@ -1,0 +1,52 @@
+from __future__ import annotations
+
+from typing import Any, Dict, Generic, Optional, Type, TypeVar
+
+from pydantic import BaseModel
+from sqlalchemy.orm import Session
+
+from app.database import Base
+
+ModelType = TypeVar("ModelType", bound=Base)
+CreateSchemaType = TypeVar("CreateSchemaType", bound=BaseModel)
+UpdateSchemaType = TypeVar("UpdateSchemaType", bound=BaseModel)
+
+
+class CRUDBase(Generic[ModelType, CreateSchemaType, UpdateSchemaType]):
+    """Generic CRUD operations."""
+
+    def __init__(self, model: Type[ModelType]):
+        self.model = model
+
+    def get(self, db: Session, id: Any) -> Optional[ModelType]:
+        return db.get(self.model, id)
+
+    def get_multi(self, db: Session, skip: int = 0, limit: int = 100) -> list[ModelType]:
+        return db.query(self.model).offset(skip).limit(limit).all()
+
+    def create(self, db: Session, obj_in: CreateSchemaType) -> ModelType:
+        obj_data: Dict[str, Any] = obj_in.model_dump()
+        db_obj = self.model(**obj_data)
+        db.add(db_obj)
+        db.commit()
+        db.refresh(db_obj)
+        return db_obj
+
+    def update(
+        self, db: Session, db_obj: ModelType, obj_in: UpdateSchemaType
+    ) -> ModelType:
+        update_data = obj_in.model_dump(exclude_unset=True)
+        for field, value in update_data.items():
+            setattr(db_obj, field, value)
+        db.add(db_obj)
+        db.commit()
+        db.refresh(db_obj)
+        return db_obj
+
+    def remove(self, db: Session, id: Any) -> Optional[ModelType]:
+        obj = db.get(self.model, id)
+        if obj is None:
+            return None
+        db.delete(obj)
+        db.commit()
+        return obj

--- a/app/database.py
+++ b/app/database.py
@@ -1,0 +1,3 @@
+from sqlalchemy.orm import declarative_base
+
+Base = declarative_base()

--- a/app/database.py
+++ b/app/database.py
@@ -4,11 +4,16 @@ from typing import Generator
 
 from sqlalchemy import create_engine
 from sqlalchemy.orm import DeclarativeBase, Session, sessionmaker
+import os
 
-DATABASE_URL = "sqlite:///./app.db"
+# database URL can be overridden with the DATABASE_URL environment variable
+DATABASE_URL = os.getenv("DATABASE_URL", "sqlite:///./app.db")
 
+# enable pool_pre_ping for a more stable connection pool
 engine = create_engine(
-    DATABASE_URL, connect_args={"check_same_thread": False}
+    DATABASE_URL,
+    connect_args={"check_same_thread": False} if DATABASE_URL.startswith("sqlite") else {},
+    pool_pre_ping=True,
 )
 SessionLocal = sessionmaker(bind=engine, autoflush=False, autocommit=False)
 

--- a/app/database.py
+++ b/app/database.py
@@ -1,3 +1,27 @@
-from sqlalchemy.orm import declarative_base
+from __future__ import annotations
 
-Base = declarative_base()
+from typing import Generator
+
+from sqlalchemy import create_engine
+from sqlalchemy.orm import DeclarativeBase, Session, sessionmaker
+
+DATABASE_URL = "sqlite:///./app.db"
+
+engine = create_engine(
+    DATABASE_URL, connect_args={"check_same_thread": False}
+)
+SessionLocal = sessionmaker(bind=engine, autoflush=False, autocommit=False)
+
+
+class Base(DeclarativeBase):
+    """Base declarative class for all models."""
+    pass
+
+
+def get_db() -> Generator[Session, None, None]:
+    """Yield a SQLAlchemy session."""
+    db = SessionLocal()
+    try:
+        yield db
+    finally:
+        db.close()

--- a/app/models/__init__.py
+++ b/app/models/__init__.py
@@ -1,0 +1,49 @@
+from .base import (
+    Base,
+    TimestampMixin,
+    SoftDeleteMixin,
+    ContactMixin,
+    HospitalType,
+    AccreditationStatus,
+    PaymentStatus,
+    TaskPriority,
+    LeadStatus,
+    UserRole,
+)
+from .user import User
+from .client import Client, ContactPerson
+from .service import Service
+from .lead import Lead
+from .project import Project, Quote, Agreement, Milestone
+from .payment import Payment
+from .document import Document
+from .task import Task
+from .note import Note
+from .notification import Notification
+
+__all__ = [
+    "Base",
+    "TimestampMixin",
+    "SoftDeleteMixin",
+    "ContactMixin",
+    "HospitalType",
+    "AccreditationStatus",
+    "PaymentStatus",
+    "TaskPriority",
+    "LeadStatus",
+    "UserRole",
+    "User",
+    "Client",
+    "ContactPerson",
+    "Service",
+    "Lead",
+    "Project",
+    "Quote",
+    "Agreement",
+    "Milestone",
+    "Payment",
+    "Document",
+    "Task",
+    "Note",
+    "Notification",
+]

--- a/app/models/base.py
+++ b/app/models/base.py
@@ -1,0 +1,72 @@
+from sqlalchemy import Column, Date, DateTime, Enum, Float, Integer, String, Text, Boolean, ForeignKey, UniqueConstraint, func
+from sqlalchemy.orm import relationship, validates
+from app.database import Base
+import enum
+import re
+
+# Enums
+class HospitalType(str, enum.Enum):
+    SINGLE_SPECIALTY = "Single Specialty"
+    MULTI_SPECIALTY = "Multi Specialty"
+    CLINIC = "Clinic"
+    DIAGNOSTIC_CENTER = "Diagnostic Center"
+    HOSPITAL_CHAIN = "Hospital Chain"
+
+class AccreditationStatus(str, enum.Enum):
+    DRAFT = "Draft"
+    IN_PROGRESS = "In Progress"
+    ACCREDITED = "Accredited"
+    REJECTED = "Rejected"
+    RENEWAL_PENDING = "Renewal Pending"
+
+class PaymentStatus(str, enum.Enum):
+    PENDING = "Pending"
+    PARTIAL = "Partial"
+    PAID = "Paid"
+    OVERDUE = "Overdue"
+    REFUNDED = "Refunded"
+
+class TaskPriority(str, enum.Enum):
+    LOW = "Low"
+    MEDIUM = "Medium"
+    HIGH = "High"
+    CRITICAL = "Critical"
+
+class LeadStatus(str, enum.Enum):
+    NEW = "New"
+    CONTACTED = "Contacted"
+    QUALIFIED = "Qualified"
+    PROPOSAL_SENT = "Proposal Sent"
+    NEGOTIATION = "Negotiation"
+    CONVERTED = "Converted"
+    CLOSED_LOST = "Closed Lost"
+    ON_HOLD = "On Hold"
+
+class UserRole(str, enum.Enum):
+    ADMIN = "admin"
+    MANAGER = "manager"
+    USER = "user"
+
+# Mixins
+class TimestampMixin:
+    created_at = Column(DateTime, server_default=func.now())
+    updated_at = Column(DateTime, onupdate=func.now())
+
+class SoftDeleteMixin:
+    is_deleted = Column(Boolean, default=False)
+
+class ContactMixin:
+    email = Column(String(120), index=True)
+    phone = Column(String(20))
+    whatsapp = Column(String(20))
+    address = Column(Text)
+    city = Column(String(50))
+    state = Column(String(50))
+    country = Column(String(50), default="India")
+    postal_code = Column(String(15))
+
+    @validates("phone", "whatsapp")
+    def validate_phone(self, key, value):
+        if value and not value.startswith("+"):
+            raise ValueError("Phone number must start with '+'")
+        return value

--- a/app/models/client.py
+++ b/app/models/client.py
@@ -1,0 +1,32 @@
+from sqlalchemy import Boolean, Column, ForeignKey, Integer, String, Enum
+from sqlalchemy.orm import relationship
+from .base import Base, ContactMixin, TimestampMixin, SoftDeleteMixin, HospitalType
+
+class Client(Base, ContactMixin, TimestampMixin, SoftDeleteMixin):
+    __tablename__ = "clients"
+    id = Column(Integer, primary_key=True)
+    name = Column(String(100))
+    hospital_name = Column(String(200))
+    beds = Column(Integer)
+    hospital_type = Column(Enum(HospitalType))
+    director_name = Column(String(100))
+    website = Column(String(200))
+    is_active = Column(Boolean, default=True)
+
+    projects = relationship("Project", back_populates="client", cascade="all, delete-orphan")
+    leads = relationship("Lead", back_populates="client", cascade="all, delete-orphan")
+    payments = relationship("Payment", back_populates="client", cascade="all, delete-orphan")
+    contacts = relationship("ContactPerson", back_populates="client", cascade="all, delete-orphan")
+    documents = relationship("Document", back_populates="client")
+
+class ContactPerson(Base, TimestampMixin):
+    __tablename__ = "contact_persons"
+    id = Column(Integer, primary_key=True)
+    client_id = Column(Integer, ForeignKey("clients.id"))
+    name = Column(String(100))
+    designation = Column(String(100))
+    email = Column(String(120))
+    phone = Column(String(20))
+    is_primary = Column(Boolean, default=False)
+
+    client = relationship("Client", back_populates="contacts")

--- a/app/models/document.py
+++ b/app/models/document.py
@@ -1,0 +1,18 @@
+from sqlalchemy import Column, ForeignKey, Integer, String
+from sqlalchemy.orm import relationship
+from .base import Base, TimestampMixin
+
+class Document(Base, TimestampMixin):
+    __tablename__ = "documents"
+    id = Column(Integer, primary_key=True)
+    client_id = Column(Integer, ForeignKey("clients.id"))
+    lead_id = Column(Integer, ForeignKey("leads.id"))
+    project_id = Column(Integer, ForeignKey("projects.id"))
+    name = Column(String(200))
+    document_type = Column(String(50))
+    file_url = Column(String(400))
+    uploaded_by_id = Column(Integer, ForeignKey("users.id"))
+
+    client = relationship("Client", back_populates="documents")
+    lead = relationship("Lead", back_populates="documents")
+    uploaded_by = relationship("User")

--- a/app/models/lead.py
+++ b/app/models/lead.py
@@ -1,0 +1,27 @@
+from sqlalchemy import Column, DateTime, Enum, Float, ForeignKey, Integer, String, UniqueConstraint
+from sqlalchemy.orm import relationship
+from .base import Base, TimestampMixin, SoftDeleteMixin, LeadStatus, TaskPriority
+
+class Lead(Base, TimestampMixin, SoftDeleteMixin):
+    __tablename__ = "leads"
+    id = Column(Integer, primary_key=True)
+    client_id = Column(Integer, ForeignKey("clients.id"))
+    service_id = Column(Integer, ForeignKey("services.id"))
+    source = Column(String(100))
+    status = Column(Enum(LeadStatus), default=LeadStatus.NEW, index=True)
+    probability = Column(Integer, default=30)
+    priority = Column(Enum(TaskPriority), default=TaskPriority.MEDIUM)
+    assigned_to_id = Column(Integer, ForeignKey("users.id"))
+    next_follow_up = Column(DateTime, index=True)
+    estimated_value = Column(Float)
+
+    __table_args__ = (
+        UniqueConstraint("client_id", "service_id", name="uq_lead_per_service_per_client"),
+    )
+
+    client = relationship("Client", back_populates="leads")
+    service = relationship("Service", back_populates="leads")
+    assigned_to = relationship("User", back_populates="assigned_leads")
+    notes = relationship("Note", back_populates="lead")
+    tasks = relationship("Task", back_populates="lead")
+    documents = relationship("Document", back_populates="lead")

--- a/app/models/note.py
+++ b/app/models/note.py
@@ -1,0 +1,15 @@
+from sqlalchemy import Column, ForeignKey, Integer, Text
+from sqlalchemy.orm import relationship
+from .base import Base, TimestampMixin
+
+class Note(Base, TimestampMixin):
+    __tablename__ = "notes"
+    id = Column(Integer, primary_key=True)
+    content = Column(Text)
+    author_id = Column(Integer, ForeignKey("users.id"))
+    lead_id = Column(Integer, ForeignKey("leads.id"))
+    project_id = Column(Integer, ForeignKey("projects.id"))
+
+    author = relationship("User", back_populates="notes")
+    lead = relationship("Lead", back_populates="notes")
+    project = relationship("Project")

--- a/app/models/notification.py
+++ b/app/models/notification.py
@@ -1,0 +1,14 @@
+from sqlalchemy import Boolean, Column, ForeignKey, Integer, String, Text
+from sqlalchemy.orm import relationship
+from .base import Base, TimestampMixin
+
+class Notification(Base, TimestampMixin):
+    __tablename__ = "notifications"
+    id = Column(Integer, primary_key=True)
+    user_id = Column(Integer, ForeignKey("users.id"))
+    message = Column(Text)
+    is_read = Column(Boolean, default=False)
+    link_to = Column(String(200))
+    notification_type = Column(String(50))
+
+    user = relationship("User", back_populates="notifications")

--- a/app/models/payment.py
+++ b/app/models/payment.py
@@ -1,0 +1,19 @@
+from sqlalchemy import Column, Date, Enum, Float, ForeignKey, Integer, String, Text
+from sqlalchemy.orm import relationship
+from .base import Base, TimestampMixin, PaymentStatus
+
+class Payment(Base, TimestampMixin):
+    __tablename__ = "payments"
+    id = Column(Integer, primary_key=True)
+    client_id = Column(Integer, ForeignKey("clients.id"), index=True)
+    project_id = Column(Integer, ForeignKey("projects.id"), index=True)
+    amount = Column(Float)
+    due_date = Column(Date)
+    paid_date = Column(Date)
+    reference_no = Column(String(100))
+    status = Column(Enum(PaymentStatus), default=PaymentStatus.PENDING)
+    payment_method = Column(String(50))
+    notes = Column(Text)
+
+    client = relationship("Client", back_populates="payments")
+    project = relationship("Project", back_populates="payments")

--- a/app/models/project.py
+++ b/app/models/project.py
@@ -1,0 +1,63 @@
+from sqlalchemy import Column, Date, Enum, Float, ForeignKey, Integer, String, Text, Boolean
+from sqlalchemy.orm import relationship
+from .base import Base, TimestampMixin, SoftDeleteMixin, AccreditationStatus
+
+class Project(Base, TimestampMixin, SoftDeleteMixin):
+    __tablename__ = "projects"
+    id = Column(Integer, primary_key=True)
+    client_id = Column(Integer, ForeignKey("clients.id"))
+    service_id = Column(Integer, ForeignKey("services.id"))
+    title = Column(String(200))
+    status = Column(Enum(AccreditationStatus), default=AccreditationStatus.DRAFT)
+    start_date = Column(Date)
+    target_date = Column(Date)
+    completed_date = Column(Date)
+    expected_fee = Column(Float)
+    actual_fee = Column(Float)
+
+    client = relationship("Client", back_populates="projects")
+    service = relationship("Service", back_populates="projects")
+    quotes = relationship("Quote", back_populates="project", cascade="all, delete-orphan")
+    agreements = relationship("Agreement", back_populates="project", cascade="all, delete-orphan")
+    tasks = relationship("Task", back_populates="project")
+    milestones = relationship("Milestone", back_populates="project")
+    payments = relationship("Payment", back_populates="project", lazy="selectin")
+
+class Quote(Base, TimestampMixin):
+    __tablename__ = "quotes"
+    id = Column(Integer, primary_key=True)
+    project_id = Column(Integer, ForeignKey("projects.id"))
+    version = Column(Integer, default=1)
+    quote_no = Column(String(50), unique=True)
+    amount = Column(Float)
+    discount_pct = Column(Float)
+    valid_until = Column(Date)
+    terms = Column(Text)
+    is_accepted = Column(Boolean, default=False)
+
+    project = relationship("Project", back_populates="quotes")
+
+class Agreement(Base, TimestampMixin):
+    __tablename__ = "agreements"
+    id = Column(Integer, primary_key=True)
+    project_id = Column(Integer, ForeignKey("projects.id"))
+    agreement_no = Column(String(50), unique=True)
+    start_date = Column(Date)
+    end_date = Column(Date)
+    signed_date = Column(Date)
+    file_url = Column(String(400))
+    termination_clause = Column(Text)
+    is_active = Column(Boolean, default=True)
+
+    project = relationship("Project", back_populates="agreements")
+
+class Milestone(Base, TimestampMixin):
+    __tablename__ = "milestones"
+    id = Column(Integer, primary_key=True)
+    project_id = Column(Integer, ForeignKey("projects.id"))
+    name = Column(String(150))
+    target_date = Column(Date)
+    completed_date = Column(Date)
+    status = Column(String(30), default="Pending")
+
+    project = relationship("Project", back_populates="milestones")

--- a/app/models/service.py
+++ b/app/models/service.py
@@ -1,0 +1,15 @@
+from sqlalchemy import Boolean, Column, Float, Integer, String, Text
+from sqlalchemy.orm import relationship
+from .base import Base, TimestampMixin
+
+class Service(Base, TimestampMixin):
+    __tablename__ = "services"
+    id = Column(Integer, primary_key=True)
+    name = Column(String(100), unique=True)
+    description = Column(Text)
+    standard_fee = Column(Float)
+    duration_days = Column(Integer)
+    is_active = Column(Boolean, default=True)
+
+    leads = relationship("Lead", back_populates="service")
+    projects = relationship("Project", back_populates="service")

--- a/app/models/task.py
+++ b/app/models/task.py
@@ -1,0 +1,19 @@
+from sqlalchemy import Column, DateTime, Enum, ForeignKey, Integer, String, Text
+from sqlalchemy.orm import relationship
+from .base import Base, TimestampMixin, TaskPriority
+
+class Task(Base, TimestampMixin):
+    __tablename__ = "tasks"
+    id = Column(Integer, primary_key=True)
+    title = Column(String(200))
+    description = Column(Text)
+    due_date = Column(DateTime)
+    priority = Column(Enum(TaskPriority), default=TaskPriority.MEDIUM)
+    status = Column(String(20), default="Pending")
+    assigned_to_id = Column(Integer, ForeignKey("users.id"))
+    lead_id = Column(Integer, ForeignKey("leads.id"))
+    project_id = Column(Integer, ForeignKey("projects.id"))
+
+    assigned_to = relationship("User", back_populates="tasks")
+    lead = relationship("Lead", back_populates="tasks")
+    project = relationship("Project", back_populates="tasks")

--- a/app/models/user.py
+++ b/app/models/user.py
@@ -1,0 +1,27 @@
+from sqlalchemy import Boolean, Column, DateTime, Integer, String, Enum
+from sqlalchemy.orm import relationship, validates
+from .base import Base, TimestampMixin, SoftDeleteMixin, UserRole
+import re
+
+class User(Base, TimestampMixin, SoftDeleteMixin):
+    __tablename__ = "users"
+    id = Column(Integer, primary_key=True)
+    username = Column(String(50), unique=True)
+    email = Column(String(120), unique=True)
+    password_hash = Column(String(128))
+    full_name = Column(String(100))
+    role = Column(Enum(UserRole), default=UserRole.USER)
+    token_version = Column(Integer, default=0)
+    is_active = Column(Boolean, default=True)
+    last_login = Column(DateTime)
+
+    assigned_leads = relationship("Lead", back_populates="assigned_to")
+    tasks = relationship("Task", back_populates="assigned_to")
+    notes = relationship("Note", back_populates="author")
+    notifications = relationship("Notification", back_populates="user")
+
+    @validates("email")
+    def validate_email(self, key, email):
+        if email and not re.match(r"[^@]+@[^@]+\.[^@]+", email):
+            raise ValueError("Invalid email address")
+        return email

--- a/app/schemas/__init__.py
+++ b/app/schemas/__init__.py
@@ -1,0 +1,41 @@
+from __future__ import annotations
+
+from app.models import (
+    Client,
+    Document,
+    Lead,
+    Note,
+    Notification,
+    Payment,
+    Project,
+    Service,
+    Task,
+    User,
+)
+
+from .factory import create_schemas
+
+MODELS = [
+    User,
+    Client,
+    Lead,
+    Project,
+    Payment,
+    Service,
+    Document,
+    Task,
+    Note,
+    Notification,
+]
+
+for m in MODELS:
+    create, read, update = create_schemas(m)
+    globals()[f"{m.__name__}Create"] = create
+    globals()[f"{m.__name__}Read"] = read
+    globals()[f"{m.__name__}Update"] = update
+
+__all__ = []
+for m in MODELS:
+    __all__.extend(
+        [f"{m.__name__}Create", f"{m.__name__}Read", f"{m.__name__}Update"]
+    )

--- a/app/schemas/__init__.py
+++ b/app/schemas/__init__.py
@@ -39,3 +39,8 @@ for m in MODELS:
     __all__.extend(
         [f"{m.__name__}Create", f"{m.__name__}Read", f"{m.__name__}Update"]
     )
+
+# authentication schemas
+from .auth import Token
+
+__all__.append("Token")

--- a/app/schemas/auth.py
+++ b/app/schemas/auth.py
@@ -1,0 +1,6 @@
+from pydantic import BaseModel
+
+
+class Token(BaseModel):
+    access_token: str
+    token_type: str = "bearer"

--- a/app/schemas/factory.py
+++ b/app/schemas/factory.py
@@ -1,0 +1,37 @@
+from __future__ import annotations
+
+from typing import Any, Dict, Optional, Tuple, Type
+
+from pydantic import BaseModel, ConfigDict, create_model
+from sqlalchemy.orm import DeclarativeMeta
+
+
+def create_schemas(
+    model: Type[DeclarativeMeta],
+) -> Tuple[Type[BaseModel], Type[BaseModel], Type[BaseModel]]:
+    """Generate Pydantic schemas for the given SQLAlchemy model.
+
+    Returns a tuple of (CreateSchema, ReadSchema, UpdateSchema).
+    """
+
+    def _schema(exclude_pk: bool, partial: bool) -> Type[BaseModel]:
+        fields: Dict[str, tuple[type[Any], Any]] = {}
+        for column in model.__table__.columns:
+            if exclude_pk and column.primary_key:
+                continue
+            python_type = getattr(column.type, "python_type", Any)
+            default = None
+            if column.default is not None and column.default.is_scalar:
+                default = column.default.arg
+            if not partial and not column.nullable and default is None and not column.primary_key:
+                fields[column.name] = (python_type, ...)
+            else:
+                fields[column.name] = (Optional[python_type], default)
+        schema = create_model(
+            f"{model.__name__}{'Update' if partial else ('Create' if exclude_pk else 'Read')}",
+            **fields,  # type: ignore[arg-type]
+        )
+        schema.model_config = ConfigDict(from_attributes=True)
+        return schema
+
+    return _schema(True, False), _schema(False, False), _schema(True, True)

--- a/app/security.py
+++ b/app/security.py
@@ -1,0 +1,29 @@
+from datetime import datetime, timedelta
+from typing import Optional
+
+from jose import jwt
+from passlib.context import CryptContext
+import os
+
+SECRET_KEY = os.getenv("SECRET_KEY", "CHANGE_ME")
+ALGORITHM = "HS256"
+ACCESS_TOKEN_EXPIRE_MINUTES = 30
+
+pwd_context = CryptContext(schemes=["bcrypt"], deprecated="auto")
+
+
+def verify_password(plain_password: str, hashed_password: str) -> bool:
+    """Verify a plain password against its hash."""
+    return pwd_context.verify(plain_password, hashed_password)
+
+
+def get_password_hash(password: str) -> str:
+    """Hash a password for storing."""
+    return pwd_context.hash(password)
+
+
+def create_access_token(subject: str, expires_delta: Optional[timedelta] = None) -> str:
+    """Generate a JWT token for the given subject."""
+    expire = datetime.utcnow() + (expires_delta or timedelta(minutes=ACCESS_TOKEN_EXPIRE_MINUTES))
+    to_encode = {"sub": subject, "exp": expire}
+    return jwt.encode(to_encode, SECRET_KEY, algorithm=ALGORITHM)

--- a/main.py
+++ b/main.py
@@ -1,0 +1,11 @@
+from fastapi import FastAPI
+
+from app.api import api_router
+from app.database import Base, engine
+
+app = FastAPI()
+
+# create database tables
+Base.metadata.create_all(bind=engine)
+
+app.include_router(api_router)


### PR DESCRIPTION
## Summary
- factor models into dedicated modules for each domain
- centralize enums and mixins in a shared base module and expose them via models package
- refine models with role enum, token version, phone validation, and performance indexes

## Testing
- `python -m py_compile $(find app -name '*.py')`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68958cd100b08329ad08e3232ad76b77