### PR TITLE
feat(api): add role-based dependency

### DIFF
--- a/app/api/__init__.py
+++ b/app/api/__init__.py
@@ -1,0 +1,6 @@
+"""API package providing dependencies and router utilities."""
+
+from .auth import require_role
+from .router import router_factory
+
+__all__ = ["require_role", "router_factory"]

--- a/app/api/auth.py
+++ b/app/api/auth.py
@@ -1,0 +1,42 @@
+"""Authentication dependencies for API routes."""
+
+from typing import Iterable
+
+from fastapi import Depends, HTTPException, status
+
+from app.models.user import User
+from app.models.base import UserRole
+
+
+async def require_user() -> User:  # pragma: no cover - placeholder
+    """Retrieve the currently authenticated user.
+
+    This is a stub to be replaced with the project's actual authentication
+    mechanism. It raises ``HTTPException`` to indicate that authentication is
+    required.
+    """
+    raise HTTPException(
+        status_code=status.HTTP_401_UNAUTHORIZED,
+        detail="Not authenticated",
+    )
+
+
+def require_role(*roles: Iterable[UserRole]):
+    """Return a dependency ensuring the current user has one of ``roles``.
+
+    Parameters
+    ----------
+    *roles:
+        Allowed :class:`~app.models.base.UserRole` values. At least one role must
+        match the authenticated user's role for the request to proceed.
+    """
+
+    async def dependency(user: User = Depends(require_user)) -> User:
+        if roles and user.role not in roles:
+            raise HTTPException(
+                status_code=status.HTTP_403_FORBIDDEN,
+                detail="Insufficient permissions",
+            )
+        return user
+
+    return dependency

--- a/app/api/router.py
+++ b/app/api/router.py
@@ -1,0 +1,35 @@
+"""Utilities for creating API routers with common dependencies."""
+
+from typing import Iterable, List, Optional
+
+from fastapi import APIRouter, Depends
+
+from app.models.base import UserRole
+from .auth import require_role
+
+
+def router_factory(
+    *,
+    prefix: str = "",
+    tags: Optional[List[str]] = None,
+    roles: Optional[Iterable[UserRole]] = None,
+) -> APIRouter:
+    """Create an :class:`fastapi.APIRouter` with optional role enforcement.
+
+    Parameters
+    ----------
+    prefix:
+        Route prefix for the router.
+    tags:
+        Optional list of tags to apply to the router.
+    roles:
+        Optional iterable of :class:`~app.models.base.UserRole`. When provided,
+        all routes registered on the router will require the authenticated user to
+        possess one of these roles.
+    """
+
+    dependencies = []
+    if roles:
+        dependencies.append(Depends(require_role(*roles)))
+
+    return APIRouter(prefix=prefix, tags=tags or [], dependencies=dependencies)


### PR DESCRIPTION
## Summary
- add `require_role` dependency for role-based access checks
- provide a router factory supporting optional role enforcement

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68959f00e4dc8329b8a9d1f96632addf