### PR TITLE
Load environment variables and configure security via env vars

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,11 +12,11 @@
 
  ## Getting Started
 
- You can follow [this codelab](https://g.co/codelabs/gmail-add-ons) to build a
- simplified version of the add-on.
+You can follow [this codelab](https://g.co/codelabs/gmail-add-ons) to build a
+simplified version of the add-on.
 
 
- ## Usage
+## Usage
 
  After installing the add-on from the G Suite Marketplace, open Gmail on desktop
  or mobile and find an electronic receipt. Click on the icon vaguely resembling
@@ -24,11 +24,22 @@
  ![receiptPicture](https://www.gstatic.com/images/icons/material/system/1x/receipt_black_24dp.png).
  A form for specifying details about the expense will appear, with the fields
  already filled. Edit as necessary and submit the form, thereby adding
- information to a spreadsheet. You can also create a new spreadsheet from within
- the add-on.
+information to a spreadsheet. You can also create a new spreadsheet from within
+the add-on.
 
 
- ## License
+## Environment Variables
+
+The application reads configuration from the environment. Define these in a
+`.env` file or your shell before running the project:
+
+- `SECRET_KEY` – secret used for signing tokens.
+- `ALGORITHM` – algorithm used for token generation. Defaults to `HS256`.
+- `ACCESS_TOKEN_EXPIRE_MINUTES` – token expiration time in minutes. Defaults to
+  `30`.
+
+
+## License
 
  This library is licensed under Apache 2.0. Full license text is available in
  [LICENSE](LICENSE).

--- a/app/security.py
+++ b/app/security.py
@@ -1,0 +1,5 @@
+import os
+
+SECRET_KEY = os.getenv("SECRET_KEY")
+ALGORITHM = os.getenv("ALGORITHM", "HS256")
+ACCESS_TOKEN_EXPIRE_MINUTES = int(os.getenv("ACCESS_TOKEN_EXPIRE_MINUTES", 30))

--- a/main.py
+++ b/main.py
@@ -1,0 +1,4 @@
+from dotenv import load_dotenv
+
+# Load environment variables from a .env file if present
+load_dotenv()


### PR DESCRIPTION
## Summary
- load `.env` at startup using `python-dotenv`
- read security settings from environment variables
- document required environment variables

## Testing
- `pip install python-dotenv`
- `python -m pytest`
- `python main.py`


------
https://chatgpt.com/codex/tasks/task_e_68959efbe548832984b47e721daf0743