### PR TITLE
Exclude audit fields from generated schemas

### DIFF
--- a/app/schemas/__init__.py
+++ b/app/schemas/__init__.py
@@ -1,0 +1,16 @@
+from .user import UserCreate, UserUpdate
+from .client import ClientCreate, ClientUpdate
+from .contactperson import ContactPersonCreate, ContactPersonUpdate
+from .service import ServiceCreate, ServiceUpdate
+from .lead import LeadCreate, LeadUpdate
+from .project import ProjectCreate, ProjectUpdate
+from .quote import QuoteCreate, QuoteUpdate
+from .agreement import AgreementCreate, AgreementUpdate
+from .milestone import MilestoneCreate, MilestoneUpdate
+from .payment import PaymentCreate, PaymentUpdate
+from .document import DocumentCreate, DocumentUpdate
+from .task import TaskCreate, TaskUpdate
+from .note import NoteCreate, NoteUpdate
+from .notification import NotificationCreate, NotificationUpdate
+
+__all__ = ["UserCreate", "UserUpdate", "ClientCreate", "ClientUpdate", "ContactPersonCreate", "ContactPersonUpdate", "ServiceCreate", "ServiceUpdate", "LeadCreate", "LeadUpdate", "ProjectCreate", "ProjectUpdate", "QuoteCreate", "QuoteUpdate", "AgreementCreate", "AgreementUpdate", "MilestoneCreate", "MilestoneUpdate", "PaymentCreate", "PaymentUpdate", "DocumentCreate", "DocumentUpdate", "TaskCreate", "TaskUpdate", "NoteCreate", "NoteUpdate", "NotificationCreate", "NotificationUpdate"]

--- a/app/schemas/agreement.py
+++ b/app/schemas/agreement.py
@@ -1,0 +1,24 @@
+# This file is auto-generated. Do not edit manually.
+from datetime import date
+from pydantic import BaseModel
+from typing import Optional
+
+class AgreementCreate(BaseModel):
+    project_id: Optional[int] = None
+    agreement_no: Optional[str] = None
+    start_date: Optional[date] = None
+    end_date: Optional[date] = None
+    signed_date: Optional[date] = None
+    file_url: Optional[str] = None
+    termination_clause: Optional[str] = None
+    is_active: Optional[bool] = None
+
+class AgreementUpdate(BaseModel):
+    project_id: Optional[int] = None
+    agreement_no: Optional[str] = None
+    start_date: Optional[date] = None
+    end_date: Optional[date] = None
+    signed_date: Optional[date] = None
+    file_url: Optional[str] = None
+    termination_clause: Optional[str] = None
+    is_active: Optional[bool] = None

--- a/app/schemas/client.py
+++ b/app/schemas/client.py
@@ -1,0 +1,38 @@
+# This file is auto-generated. Do not edit manually.
+from app.models.base import HospitalType
+from pydantic import BaseModel
+from typing import Optional
+
+class ClientCreate(BaseModel):
+    name: Optional[str] = None
+    hospital_name: Optional[str] = None
+    beds: Optional[int] = None
+    hospital_type: Optional[HospitalType] = None
+    director_name: Optional[str] = None
+    website: Optional[str] = None
+    is_active: Optional[bool] = None
+    email: Optional[str] = None
+    phone: Optional[str] = None
+    whatsapp: Optional[str] = None
+    address: Optional[str] = None
+    city: Optional[str] = None
+    state: Optional[str] = None
+    country: Optional[str] = None
+    postal_code: Optional[str] = None
+
+class ClientUpdate(BaseModel):
+    name: Optional[str] = None
+    hospital_name: Optional[str] = None
+    beds: Optional[int] = None
+    hospital_type: Optional[HospitalType] = None
+    director_name: Optional[str] = None
+    website: Optional[str] = None
+    is_active: Optional[bool] = None
+    email: Optional[str] = None
+    phone: Optional[str] = None
+    whatsapp: Optional[str] = None
+    address: Optional[str] = None
+    city: Optional[str] = None
+    state: Optional[str] = None
+    country: Optional[str] = None
+    postal_code: Optional[str] = None

--- a/app/schemas/contactperson.py
+++ b/app/schemas/contactperson.py
@@ -1,0 +1,19 @@
+# This file is auto-generated. Do not edit manually.
+from pydantic import BaseModel
+from typing import Optional
+
+class ContactPersonCreate(BaseModel):
+    client_id: Optional[int] = None
+    name: Optional[str] = None
+    designation: Optional[str] = None
+    email: Optional[str] = None
+    phone: Optional[str] = None
+    is_primary: Optional[bool] = None
+
+class ContactPersonUpdate(BaseModel):
+    client_id: Optional[int] = None
+    name: Optional[str] = None
+    designation: Optional[str] = None
+    email: Optional[str] = None
+    phone: Optional[str] = None
+    is_primary: Optional[bool] = None

--- a/app/schemas/document.py
+++ b/app/schemas/document.py
@@ -1,0 +1,21 @@
+# This file is auto-generated. Do not edit manually.
+from pydantic import BaseModel
+from typing import Optional
+
+class DocumentCreate(BaseModel):
+    client_id: Optional[int] = None
+    lead_id: Optional[int] = None
+    project_id: Optional[int] = None
+    name: Optional[str] = None
+    document_type: Optional[str] = None
+    file_url: Optional[str] = None
+    uploaded_by_id: Optional[int] = None
+
+class DocumentUpdate(BaseModel):
+    client_id: Optional[int] = None
+    lead_id: Optional[int] = None
+    project_id: Optional[int] = None
+    name: Optional[str] = None
+    document_type: Optional[str] = None
+    file_url: Optional[str] = None
+    uploaded_by_id: Optional[int] = None

--- a/app/schemas/factory.py
+++ b/app/schemas/factory.py
@@ -1,0 +1,92 @@
+import enum
+from pathlib import Path
+from typing import Optional, Set
+
+from sqlalchemy import inspect
+
+from app.models import Base
+
+EXCLUDE_COLUMNS = {"id", "created_at", "updated_at", "is_deleted"}
+
+
+def _python_type(column):
+    try:
+        return column.type.python_type
+    except NotImplementedError:  # fallback when type doesn't expose python_type
+        return str
+
+
+def _imports_and_field(column, optional: bool) -> tuple[Set[str], str]:
+    col_type = _python_type(column)
+    imports: Set[str] = set()
+    type_name = col_type.__name__
+    if isinstance(col_type, type) and issubclass(col_type, enum.Enum):
+        imports.add(f"from app.models.base import {type_name}")
+    elif col_type.__module__ == "datetime":
+        imports.add(f"from datetime import {type_name}")
+    if optional:
+        imports.add("from typing import Optional")
+        annotation = f"Optional[{type_name}]"
+        default = "None"
+    else:
+        annotation = type_name
+        default = "..."
+    field_line = f"    {column.key}: {annotation} = {default}"
+    return imports, field_line
+
+
+def generate_schema(model):
+    mapper = inspect(model)
+    create_fields = []
+    update_fields = []
+    imports: Set[str] = {"from pydantic import BaseModel"}
+    for column in mapper.columns:
+        if column.key in EXCLUDE_COLUMNS:
+            continue
+        required = (
+            not column.nullable
+            and column.default is None
+            and column.server_default is None
+            and not column.autoincrement
+            and not column.primary_key
+        )
+        imp, line = _imports_and_field(column, optional=not required)
+        imports.update(imp)
+        create_fields.append(line)
+        # Update models always optional
+        imp_u, line_u = _imports_and_field(column, optional=True)
+        imports.update(imp_u)
+        update_fields.append(line_u)
+    imports_block = "\n".join(sorted(imports)) + "\n\n"
+    create_block = [f"class {model.__name__}Create(BaseModel):"]
+    create_block.extend(create_fields or ["    pass"])
+    create_block.append("")
+    update_block = [f"class {model.__name__}Update(BaseModel):"]
+    update_block.extend(update_fields or ["    pass"])
+    update_block.append("")
+    return imports_block + "\n".join(create_block + update_block)
+
+
+def main():
+    base_path = Path(__file__).parent
+    for model in Base.__subclasses__():
+        code = generate_schema(model)
+        file_path = base_path / f"{model.__name__.lower()}.py"
+        file_path.write_text(
+            "# This file is auto-generated. Do not edit manually.\n" + code
+        )
+    # regenerate __init__.py
+    init_lines = []
+    names = []
+    for model in Base.__subclasses__():
+        name = model.__name__.lower()
+        init_lines.append(
+            f"from .{name} import {model.__name__}Create, {model.__name__}Update"
+        )
+        names.extend([f"{model.__name__}Create", f"{model.__name__}Update"])
+    init_lines.append("\n__all__ = [" + ", ".join(f'\"{n}\"' for n in names) + "]\n")
+    (base_path / "__init__.py").write_text("\n".join(init_lines))
+
+
+if __name__ == "__main__":
+    main()

--- a/app/schemas/lead.py
+++ b/app/schemas/lead.py
@@ -1,0 +1,28 @@
+# This file is auto-generated. Do not edit manually.
+from app.models.base import LeadStatus
+from app.models.base import TaskPriority
+from datetime import datetime
+from pydantic import BaseModel
+from typing import Optional
+
+class LeadCreate(BaseModel):
+    client_id: Optional[int] = None
+    service_id: Optional[int] = None
+    source: Optional[str] = None
+    status: Optional[LeadStatus] = None
+    probability: Optional[int] = None
+    priority: Optional[TaskPriority] = None
+    assigned_to_id: Optional[int] = None
+    next_follow_up: Optional[datetime] = None
+    estimated_value: Optional[float] = None
+
+class LeadUpdate(BaseModel):
+    client_id: Optional[int] = None
+    service_id: Optional[int] = None
+    source: Optional[str] = None
+    status: Optional[LeadStatus] = None
+    probability: Optional[int] = None
+    priority: Optional[TaskPriority] = None
+    assigned_to_id: Optional[int] = None
+    next_follow_up: Optional[datetime] = None
+    estimated_value: Optional[float] = None

--- a/app/schemas/milestone.py
+++ b/app/schemas/milestone.py
@@ -1,0 +1,18 @@
+# This file is auto-generated. Do not edit manually.
+from datetime import date
+from pydantic import BaseModel
+from typing import Optional
+
+class MilestoneCreate(BaseModel):
+    project_id: Optional[int] = None
+    name: Optional[str] = None
+    target_date: Optional[date] = None
+    completed_date: Optional[date] = None
+    status: Optional[str] = None
+
+class MilestoneUpdate(BaseModel):
+    project_id: Optional[int] = None
+    name: Optional[str] = None
+    target_date: Optional[date] = None
+    completed_date: Optional[date] = None
+    status: Optional[str] = None

--- a/app/schemas/note.py
+++ b/app/schemas/note.py
@@ -1,0 +1,15 @@
+# This file is auto-generated. Do not edit manually.
+from pydantic import BaseModel
+from typing import Optional
+
+class NoteCreate(BaseModel):
+    content: Optional[str] = None
+    author_id: Optional[int] = None
+    lead_id: Optional[int] = None
+    project_id: Optional[int] = None
+
+class NoteUpdate(BaseModel):
+    content: Optional[str] = None
+    author_id: Optional[int] = None
+    lead_id: Optional[int] = None
+    project_id: Optional[int] = None

--- a/app/schemas/notification.py
+++ b/app/schemas/notification.py
@@ -1,0 +1,17 @@
+# This file is auto-generated. Do not edit manually.
+from pydantic import BaseModel
+from typing import Optional
+
+class NotificationCreate(BaseModel):
+    user_id: Optional[int] = None
+    message: Optional[str] = None
+    is_read: Optional[bool] = None
+    link_to: Optional[str] = None
+    notification_type: Optional[str] = None
+
+class NotificationUpdate(BaseModel):
+    user_id: Optional[int] = None
+    message: Optional[str] = None
+    is_read: Optional[bool] = None
+    link_to: Optional[str] = None
+    notification_type: Optional[str] = None

--- a/app/schemas/payment.py
+++ b/app/schemas/payment.py
@@ -1,0 +1,27 @@
+# This file is auto-generated. Do not edit manually.
+from app.models.base import PaymentStatus
+from datetime import date
+from pydantic import BaseModel
+from typing import Optional
+
+class PaymentCreate(BaseModel):
+    client_id: Optional[int] = None
+    project_id: Optional[int] = None
+    amount: Optional[float] = None
+    due_date: Optional[date] = None
+    paid_date: Optional[date] = None
+    reference_no: Optional[str] = None
+    status: Optional[PaymentStatus] = None
+    payment_method: Optional[str] = None
+    notes: Optional[str] = None
+
+class PaymentUpdate(BaseModel):
+    client_id: Optional[int] = None
+    project_id: Optional[int] = None
+    amount: Optional[float] = None
+    due_date: Optional[date] = None
+    paid_date: Optional[date] = None
+    reference_no: Optional[str] = None
+    status: Optional[PaymentStatus] = None
+    payment_method: Optional[str] = None
+    notes: Optional[str] = None

--- a/app/schemas/project.py
+++ b/app/schemas/project.py
@@ -1,0 +1,27 @@
+# This file is auto-generated. Do not edit manually.
+from app.models.base import AccreditationStatus
+from datetime import date
+from pydantic import BaseModel
+from typing import Optional
+
+class ProjectCreate(BaseModel):
+    client_id: Optional[int] = None
+    service_id: Optional[int] = None
+    title: Optional[str] = None
+    status: Optional[AccreditationStatus] = None
+    start_date: Optional[date] = None
+    target_date: Optional[date] = None
+    completed_date: Optional[date] = None
+    expected_fee: Optional[float] = None
+    actual_fee: Optional[float] = None
+
+class ProjectUpdate(BaseModel):
+    client_id: Optional[int] = None
+    service_id: Optional[int] = None
+    title: Optional[str] = None
+    status: Optional[AccreditationStatus] = None
+    start_date: Optional[date] = None
+    target_date: Optional[date] = None
+    completed_date: Optional[date] = None
+    expected_fee: Optional[float] = None
+    actual_fee: Optional[float] = None

--- a/app/schemas/quote.py
+++ b/app/schemas/quote.py
@@ -1,0 +1,24 @@
+# This file is auto-generated. Do not edit manually.
+from datetime import date
+from pydantic import BaseModel
+from typing import Optional
+
+class QuoteCreate(BaseModel):
+    project_id: Optional[int] = None
+    version: Optional[int] = None
+    quote_no: Optional[str] = None
+    amount: Optional[float] = None
+    discount_pct: Optional[float] = None
+    valid_until: Optional[date] = None
+    terms: Optional[str] = None
+    is_accepted: Optional[bool] = None
+
+class QuoteUpdate(BaseModel):
+    project_id: Optional[int] = None
+    version: Optional[int] = None
+    quote_no: Optional[str] = None
+    amount: Optional[float] = None
+    discount_pct: Optional[float] = None
+    valid_until: Optional[date] = None
+    terms: Optional[str] = None
+    is_accepted: Optional[bool] = None

--- a/app/schemas/service.py
+++ b/app/schemas/service.py
@@ -1,0 +1,17 @@
+# This file is auto-generated. Do not edit manually.
+from pydantic import BaseModel
+from typing import Optional
+
+class ServiceCreate(BaseModel):
+    name: Optional[str] = None
+    description: Optional[str] = None
+    standard_fee: Optional[float] = None
+    duration_days: Optional[int] = None
+    is_active: Optional[bool] = None
+
+class ServiceUpdate(BaseModel):
+    name: Optional[str] = None
+    description: Optional[str] = None
+    standard_fee: Optional[float] = None
+    duration_days: Optional[int] = None
+    is_active: Optional[bool] = None

--- a/app/schemas/task.py
+++ b/app/schemas/task.py
@@ -1,0 +1,25 @@
+# This file is auto-generated. Do not edit manually.
+from app.models.base import TaskPriority
+from datetime import datetime
+from pydantic import BaseModel
+from typing import Optional
+
+class TaskCreate(BaseModel):
+    title: Optional[str] = None
+    description: Optional[str] = None
+    due_date: Optional[datetime] = None
+    priority: Optional[TaskPriority] = None
+    status: Optional[str] = None
+    assigned_to_id: Optional[int] = None
+    lead_id: Optional[int] = None
+    project_id: Optional[int] = None
+
+class TaskUpdate(BaseModel):
+    title: Optional[str] = None
+    description: Optional[str] = None
+    due_date: Optional[datetime] = None
+    priority: Optional[TaskPriority] = None
+    status: Optional[str] = None
+    assigned_to_id: Optional[int] = None
+    lead_id: Optional[int] = None
+    project_id: Optional[int] = None

--- a/app/schemas/user.py
+++ b/app/schemas/user.py
@@ -1,0 +1,25 @@
+# This file is auto-generated. Do not edit manually.
+from app.models.base import UserRole
+from datetime import datetime
+from pydantic import BaseModel
+from typing import Optional
+
+class UserCreate(BaseModel):
+    username: Optional[str] = None
+    email: Optional[str] = None
+    password_hash: Optional[str] = None
+    full_name: Optional[str] = None
+    role: Optional[UserRole] = None
+    token_version: Optional[int] = None
+    is_active: Optional[bool] = None
+    last_login: Optional[datetime] = None
+
+class UserUpdate(BaseModel):
+    username: Optional[str] = None
+    email: Optional[str] = None
+    password_hash: Optional[str] = None
+    full_name: Optional[str] = None
+    role: Optional[UserRole] = None
+    token_version: Optional[int] = None
+    is_active: Optional[bool] = None
+    last_login: Optional[datetime] = None


### PR DESCRIPTION
## Summary
- skip `created_at`, `updated_at` and `is_deleted` when generating Pydantic schemas
- regenerate schema modules so create/update models no longer accept audit fields

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68959eff8cf48329ba7446889d9844e9